### PR TITLE
Fix chip-gn build

### DIFF
--- a/config/qpg/chip-gn/args.gni
+++ b/config/qpg/chip-gn/args.gni
@@ -32,8 +32,9 @@ qpg_cc = "arm-none-eabi-gcc"
 qpg_cxx = "arm-none-eabi-g++"
 chip_mdns = "platform"
 
-chip_project_config_include_dirs =
-    [ "//examples/platform/qpg/project_include/" ]
+# Using lighting-app as template config
+# Application specific override to be done as cmd line arg
+chip_project_config_include_dirs = [ "//examples/lighting-app/qpg/include" ]
 chip_project_config_include = "<CHIPProjectConfig.h>"
 chip_system_project_config_include = "<CHIPProjectConfig.h>"
 chip_ble_project_config_include = ""

--- a/examples/shell/qpg/args.gni
+++ b/examples/shell/qpg/args.gni
@@ -22,3 +22,7 @@ pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 chip_enable_openthread = true
 chip_build_libshell = true
+
+# Disable lock tracking, since our FreeRTOS configuration does not set
+# INCLUDE_xSemaphoreGetMutexHolder
+chip_stack_lock_tracking = "none"


### PR DESCRIPTION
#### Problem
Config folder not defined for chip-gn build

#### Change overview
Setting default config include

#### Testing
chip-gn build
